### PR TITLE
need to update RxCocoa along with the previously updated RxSwift

### DIFF
--- a/ios/tutorials/tutorial1/Podfile
+++ b/ios/tutorials/tutorial1/Podfile
@@ -5,6 +5,7 @@ inhibit_all_warnings!
 
 target 'TicTacToe' do
   pod 'RIBs', :path => '../../../'
+  pod 'RxSwift', '~> 5.0'
   pod 'SnapKit', '~> 4.0.0'
-  pod 'RxCocoa', '~> 4.0.0'
+  pod 'RxCocoa', '~> 5.0.1'
 end

--- a/ios/tutorials/tutorial2/Podfile
+++ b/ios/tutorials/tutorial2/Podfile
@@ -6,7 +6,7 @@ inhibit_all_warnings!
 target 'TicTacToe' do
   pod 'RIBs', :path => '../../../'
   pod 'SnapKit', '~> 4.0.0'
-  pod 'RxCocoa', '~> 4.0.0'
+  pod 'RxCocoa', '~> 5.0.1'
 end
 
 target 'TicTacToeTests' do

--- a/ios/tutorials/tutorial3-completed/Podfile
+++ b/ios/tutorials/tutorial3-completed/Podfile
@@ -6,5 +6,5 @@ inhibit_all_warnings!
 target 'TicTacToe' do
   pod 'RIBs', :path => '../../../'
   pod 'SnapKit', '~> 4.0.0'
-  pod 'RxCocoa', '~> 4.0.0'
+  pod 'RxCocoa', '~> 5.0.1'
 end

--- a/ios/tutorials/tutorial3/Podfile
+++ b/ios/tutorials/tutorial3/Podfile
@@ -6,5 +6,5 @@ inhibit_all_warnings!
 target 'TicTacToe' do
   pod 'RIBs', :path => '../../../'
   pod 'SnapKit', '~> 4.0.0'
-  pod 'RxCocoa', '~> 4.0.0'
+  pod 'RxCocoa', '~> 5.0.1'
 end

--- a/ios/tutorials/tutorial4-completed/Podfile
+++ b/ios/tutorials/tutorial4-completed/Podfile
@@ -6,5 +6,5 @@ inhibit_all_warnings!
 target 'TicTacToe' do
   pod 'RIBs', :path => '../../../'
   pod 'SnapKit', '~> 4.0.0'
-  pod 'RxCocoa', '~> 4.0.0'
+  pod 'RxCocoa', '~> 5.0.1'
 end

--- a/ios/tutorials/tutorial4/Podfile
+++ b/ios/tutorials/tutorial4/Podfile
@@ -6,5 +6,5 @@ inhibit_all_warnings!
 target 'TicTacToe' do
   pod 'RIBs', :path => '../../../'
   pod 'SnapKit', '~> 4.0.0'
-  pod 'RxCocoa', '~> 4.0.0'
+  pod 'RxCocoa', '~> 5.0.1'
 end


### PR DESCRIPTION
I see you closed your https://github.com/uber/RIBs/pull/369 PR.  

I'm guessing it's because you tried to build it and were seeing errors like this:

```
pod install
Analyzing dependencies
Fetching podspec for `RIBs` from `../../../`
[!] CocoaPods could not find compatible versions for pod "RxSwift":
  In Podfile:
    RIBs (from `../../../`) was resolved to 0.9.3, which depends on
      RxRelay (~> 5.0) was resolved to 5.0.0, which depends on
        RxSwift (~> 5)

    RIBs (from `../../../`) was resolved to 0.9.3, which depends on
      RxSwift (~> 5.0)

    RxCocoa (~> 4.0.0) was resolved to 4.0.0, which depends on
      RxSwift (~> 4.0)
```
Updating `RxCocoa` in the Podfiles fixes the problem and the workspaces become buildable again.  I'd definitely recommend reopening that original PR (with this update in place), as it'll help other people just getting started with RIBs, like me.  Hope this helps!
